### PR TITLE
change hook for buildHtaccess from buildStart to renderStart

### DIFF
--- a/config/vite-plugins/vite-plugin-build-htaccess.ts
+++ b/config/vite-plugins/vite-plugin-build-htaccess.ts
@@ -16,7 +16,7 @@ export default function buildHtaccessPlugin({
 }): PluginOption {
   return {
     name: "vite-plugin-build-htaccess",
-    buildStart: () => {
+    renderStart: () => {
       buildHtaccess({
         user,
         serverWebRootPath,


### PR DESCRIPTION
Change RollUp hook for `buildHtaccess` from `buildStart` to `renderStart` to prevent _.htaccess_ deletion when doing a SPA