### PR TITLE
Add env var to control hmr in vite config

### DIFF
--- a/.env
+++ b/.env
@@ -2,6 +2,8 @@
 VITE_APP_BASE="/chersite/dist/front/www/"
 # Open your browser when dev server is launch
 DEV_SERVER_OPEN=true
+# Enable HMR (Hot Reload) server connection
+DEV_SERVER_HMR=true
 
 # Buid .htaccess file from template
 BUILD_HTACCESS=true

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -59,6 +59,7 @@ export default defineConfig(({ command, mode }) => {
         process.env.DEV_SERVER_OPEN === "true"
           ? `${protocol}://${ipAddress}${process.env.VITE_APP_BASE}`
           : false,
+      hmr: process.env.DEV_SERVER_HMR === "true",
     },
 
     css: {


### PR DESCRIPTION
Sur certains projets notamment avec des instances standalones type scene webgl on a besoin de désactiver le hmr. Je propose qu'on le rajoute dans le .env.