### PR TITLE
fix/async import resolving on first file read

### DIFF
--- a/config/tasks/build-dotenv/build-dotenv.js
+++ b/config/tasks/build-dotenv/build-dotenv.js
@@ -10,8 +10,8 @@ const _getRaws = (files = []) => {
     let count = 0
     const rawsList = []
     files.forEach(async (file) => {
-      count++
       const data = await mfs.readFile(file)
+      count++
       rawsList.push(data)
       if (count === files.length) {
         resolve(rawsList)


### PR DESCRIPTION
Si laissé comme tel, la promesse sera résolue au premier fichier lu. Actuellement, seul le premier .env détecté était injecté dans le outDir.