### PR TITLE
Add VITE_APP_BASE to Manifest parser

### DIFF
--- a/apps/front/prerender/helpers/ManifestParser.ts
+++ b/apps/front/prerender/helpers/ManifestParser.ts
@@ -18,10 +18,10 @@ export class ManifestParser {
    * Directly get script Tags from raw manifest string
    * @param manifestRaw
    */
-  static getScriptTagFromManifest(manifestRaw: string): TScriptsObj {
+  static getScriptTagFromManifest(manifestRaw: string, base = "/"): TScriptsObj {
     const assets = ManifestParser.getAssets(manifestRaw)
     const assetsByType = ManifestParser.sortAssetsByType(assets)
-    return ManifestParser.getScripts(assetsByType)
+    return ManifestParser.getScripts(assetsByType, base)
   }
 
   /**

--- a/apps/front/prerender/prerender.ts
+++ b/apps/front/prerender/prerender.ts
@@ -10,6 +10,7 @@ import { ManifestParser } from "./helpers/ManifestParser"
 import { renderToPipeableStream, renderToString } from "react-dom/server"
 import { JSXElementConstructor, ReactElement } from "react"
 import { htmlReplacement } from "../src/server/helpers/htmlReplacement"
+import { loadEnv } from "vite"
 
 /**
  * Prerender
@@ -26,8 +27,9 @@ export const prerender = async (urls: string[], outDirStatic = config.outDirStat
   }
 
   // get script tags to inject in render
+  const base = process.env.VITE_APP_BASE || loadEnv("", process.cwd(), "").VITE_APP_BASE
   const manifest = await mfs.readFile(`${outDirStatic}/manifest.json`)
-  const scriptTags = ManifestParser.getScriptTagFromManifest(manifest)
+  const scriptTags = ManifestParser.getScriptTagFromManifest(manifest as string, base)
 
   // pre-render each route
   for (let url of urls) {


### PR DESCRIPTION
Add VITE_APP_BASE  as parameter to `getScriptTagFromManifest`, if not, all src are based on `/` 
