### PR TITLE
Fix page transition promise return

### DIFF
--- a/apps/front/src/components/app/App.tsx
+++ b/apps/front/src/components/app/App.tsx
@@ -15,34 +15,32 @@ function App(props: IProps): JSX.Element {
    * @param TManageTransitions
    * @returns Promise <void>
    */
-  const manageTransitions = ({
+  const manageTransitions = async ({
     previousPage,
     currentPage,
     unmountPreviousPage,
   }: TManageTransitions): Promise<void> => {
-    return new Promise(async (resolve) => {
-      const $current = currentPage?.$element
+    const $current = currentPage?.$element
 
-      // hide new page
-      if ($current) $current.style.visibility = "hidden"
+    // hide new page
+    if ($current) $current.style.visibility = "hidden"
 
-      // play out and unmount previous page
-      if (previousPage) {
-        await previousPage.playOut()
-        unmountPreviousPage()
-      }
+    // play out and unmount previous page
+    if (previousPage) {
+      await previousPage.playOut()
+      unmountPreviousPage()
+    }
 
-      // wait page isReady promise
-      await currentPage?.isReadyPromise?.()
+    // wait page isReady promise
+    await currentPage?.isReadyPromise?.()
 
-      // show and play in new page
-      if (currentPage) {
-        if ($current) $current.style.visibility = "visible"
-        await currentPage?.playIn()
-      }
+    // show and play in new page
+    if (currentPage) {
+      if ($current) $current.style.visibility = "visible"
+      await currentPage?.playIn()
+    }
 
-      resolve()
-    })
+    return Promise.resolve()
   }
 
   // ------------------------------------------------------------------------------- RENDER


### PR DESCRIPTION
Fix manage transition method promise to only return one promise with async and prevent unresolved one.