### PR TITLE
Update CLI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
         run: npm ci --unsafe-perm && cd apps/front && npm ci --unsafe-perm
 
       - name: ⚡️build front
-        run: npm run build:front
+        run: npm run front:build
 
       - name: 🙏🏽 test
-        run: npm run test:front
+        run: npm run front:test

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ docker compose exec node /bin/bash
 - Install node dependencies for the root project and install dependencies for all apps:
 
 ```shell
-npm run init
+npm i
 ```
 
 - Setup the project:
@@ -80,7 +80,7 @@ npm run setup
 Then, start the dev server:
 
 ```shell
-npm run dev:front
+npm run front:dev
 ```
 
 - Create a `apps/front/.env.local` file with your local IP (useful to access the frontend from other devices):
@@ -91,30 +91,8 @@ HOST="your local IP"
 
 ## CLI
 
-- [init](#init)
-- [dev:front](#dev-front)
-- [setup](#setup)
-- [scaffold](#scaffold)
-- [scaffold-wp](#scaffold-wp)
-
 npm scripts command line interface is available from the main [package.json](./package.json).
 Each script can be executed from `npm run {task}` command.
-
-### init
-
-```shell
-npm run init
-```
-
-Install node dependencies for the root project and install dependencies for all apps.
-
-### dev front
-
-```shell
-npm run dev:front
-```
-
-Start the dev server for the front app.
 
 ### setup
 
@@ -130,10 +108,10 @@ npm run setup
 - Create install file cache
 - Reset this current `.git` and re-init it
 
-### scaffold
+### front:scaffold
 
 ```shell
-npm run scaffold
+npm run front:scaffold
 ```
 
 Used to create a new component. [Components templates](cli/tasks/scaffold-component/templates)
@@ -157,10 +135,10 @@ bundleType: ["react", "dom"]
 componentCompatibleFolders: ["components", "pages"]
 ```
 
-### scaffold-wp
+### back:scaffold-wp
 
 ```shell
-npm run scaffold-wp
+npm run back:scaffold-wp
 ```
 
 Scaffold Page, Post type, Option pages for Wordpress.By default, it will create files in `apps/back/web/app/themes/CherAmi/`.

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,7 @@
     "": {
       "name": "chersite",
       "version": "3.0.0",
+      "hasInstallScript": true,
       "devDependencies": {
         "@cher-ami/debug": "^1.2.0",
         "@cher-ami/mfs": "^0.2.0",

--- a/package.json
+++ b/package.json
@@ -6,14 +6,14 @@
   "main": "src/index.tsx",
   "type": "module",
   "scripts": {
-    "init": "npm i && cd apps/front && npm install",
-    "dev:front": "cd apps/front && npm run dev",
-    "build:front": "cd apps/front && npm run build",
-    "test:front": "cd apps/front && npm run test",
-    "scaffold": "node cli/tasks/scaffold-component/scaffold-component.js",
-    "scaffold-wp": "node cli/tasks/scaffold-wp/scaffold-wp.js",
+    "front:dev": "cd apps/front && npm run dev",
+    "front:build": "cd apps/front && npm run build",
+    "front:test": "cd apps/front && npm run test",
+    "front:scaffold": "node cli/tasks/scaffold-component/scaffold-component.js",
+    "back:scaffold-wp": "node cli/tasks/scaffold-wp/scaffold-wp.js",
     "setup": "node cli/tasks/setup/setup.js && npm run prepare",
-    "prepare": "husky install"
+    "prepare": "husky install",
+    "postinstall": "cd apps/front && npm i"
   },
   "devDependencies": {
     "@cher-ami/debug": "^1.2.0",


### PR DESCRIPTION
- Remove `npm run init`. Just `npm i` will install root deps + apps/front/ deps by default.

Update all script names - {task}:{workspace} → {workspace}:{task} : 

- `npm run dev:front` → `npm run front:dev`
- `npm run build:front` → `npm run front:build`
- `npm run test:front` → `npm run front:test`

plus scope old global script name

- `npm run scaffold` → `npm run front:scaffold`
- `npm run scaffold-wp` → `npm run back:scaffold-wp`