### PR TITLE
fix calc detection in convertRemToPx.ts

### DIFF
--- a/apps/front/src/libs/dom/convertRemToPx.ts
+++ b/apps/front/src/libs/dom/convertRemToPx.ts
@@ -19,7 +19,7 @@ export const convertRemToPx = (pxValue: number): number => {
  * @returns
  */
 const _convertFontSizeCssVarToPx = (cssUnitValue: string): number => {
-  const isCalc = cssUnitValue.startsWith("calc")
+  const isCalc = cssUnitValue.includes("calc")
   const isVw = cssUnitValue.endsWith("vw")
   const isVh = cssUnitValue.endsWith("vh")
 


### PR DESCRIPTION
bug fix for safari 14.2.1. "calc" if contains contains whitespace