### PR TITLE
Fix ratio parameter for propertyVW

### DIFF
--- a/apps/front/src/styles/_ratio.scss
+++ b/apps/front/src/styles/_ratio.scss
@@ -27,11 +27,7 @@
 /// @param {Number} $n1
 /// @param {Number} $ratioVW []
 /// @output
-@mixin propertyVW(
-  $property,
-  $n1,
-  $ratioVW: fn.strip-units(breakpoints.$breakpoint-mobile)
-) {
+@mixin propertyVW($property, $n1, $ratioVW: viewport.$viewport-reference-width) {
   #{$property}: #{fn.ratioVW($n1, $ratioVW)};
 }
 


### PR DESCRIPTION
The mobile ratio was wrong, compared to other ratio functions. It used not the same var which result in a mismatch for the fontsize set in rem, and calculated in pixel.
